### PR TITLE
[KFSQA-1181] Add random email for required data fields on Deleivery t…

### DIFF
--- a/lib/kuality-kfs/utilities.rb
+++ b/lib/kuality-kfs/utilities.rb
@@ -58,6 +58,11 @@ module Utilities
     "#{rand(99..999)}-#{rand(99..999)}-#{rand(999..9999)}"
   end
 
+  # @return [String] A randomly generated email address that should pass KFS's requirements for email address validation. No other assurances.
+  def random_email_address
+    "#{[*('a'..'z')].sample(6).join}" + '@abc.xyz'
+  end
+
   def fiscal_period_conversion(month)
     case month
       when 'JAN', 'Jan', 'January'


### PR DESCRIPTION
…ab and Additional Institutional Info tab when either is blank or null. Increase wait time for commodity code search to 30 seconds before second attempt at data retrieval. Store restricted vendor number obtained from web service call in local variable prior to attempting setting the page value.
