### PR TITLE
[KFSQA-1188] Increase execution time allowed for batch posterBalaceJob from 20 minutes to 40 minutes as job is causing AFT failure with a current run time of just over 30 minutes.

### DIFF
--- a/lib/kuality-kfs/batch_utilities.rb
+++ b/lib/kuality-kfs/batch_utilities.rb
@@ -36,7 +36,7 @@ module BatchUtilities
   end
 
   def run_poster_balancing(wait_for_completion = false)
-    run_unscheduled_job('posterBalancingJob', wait_for_completion, 1200)
+    run_unscheduled_job('posterBalancingJob', wait_for_completion, 2400)
   end
 
   def run_clear_pending_entries(wait_for_completion = false)


### PR DESCRIPTION
This change was verified by doing a run from this code branch on the server.
Refer to console output log #421 of Jenkins job Run Cucumber Tests for the successful run that took 51m21.419s.

There are only changes on kuallity-kfs to address this issue.
