### PR TITLE
[KDO-1359] Added dependency for specific selenium webdriver version.

### DIFF
--- a/kuality-kfs.gemspec
+++ b/kuality-kfs.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
     s.authors = ['Cornell University']
     s.email = %w{"tony@rsmart.com"}
     s.homepage = 'https://github.com/CU-CommunityApps'
+    s.add_dependency 'selenium-webdriver', '2.53.4'
     s.add_dependency 'test-factory', '0.5.3'
     s.required_ruby_version = '>= 1.9.2'
 end


### PR DESCRIPTION
 The new release of the selenium webdriver (v3.0.0) on October 13, 2016 requires Ruby version 2.0. This new vendor release broke our server environment for the current automated functional tests (AFT's) that validate against  KFS v5.3.1.  

Since we are in the process of upgrading/changing that AFT environment and those tests to KFS v7.x, the most expedient fix was to force the server environment back to the last known revision of the selenium web driver (v2.53.4) that worked for the version of Ruby we are using on the server.

This change has been verified on the server with AFT Jenkins Utility ==> Run Cucumber Tests Build 456.  There are no changes needed on the kuality-kfs-cu code branch to fix this issue.
